### PR TITLE
ci.sbt: Use wildcards for scala versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.15]
+        scala: [2.13.x]
         java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,12 +85,12 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Download target directories (2.13.15)
+      - name: Download target directories (2.13.x)
         uses: actions/download-artifact@v4
         with:
-          name: target-${{ matrix.os }}-2.13.15-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.13.x-${{ matrix.java }}
 
-      - name: Inflate target directories (2.13.15)
+      - name: Inflate target directories (2.13.x)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
       - or:
           - author=scala-steward
           - author=nafg-scala-steward[bot]
-      - check-success=Build and Test (ubuntu-latest, 2.13.15, zulu@8)
+      - check-success=Build and Test (ubuntu-latest, 2.13.x, zulu@8)
     actions:
         queue:
             name: default

--- a/ci.sbt
+++ b/ci.sbt
@@ -15,13 +15,14 @@ val jgit      = new Git(repo)
 val remoteUrl = jgit.remoteList().call().asScala.filter(_.getName == "origin").flatMap(_.getURIs.asScala).headOption
 
 inThisBuild(List(
-  homepage                := remoteUrl.map(u => url(s"https://${u.getHost}/${u.getPath.stripSuffix(".git")}")),
-  licenses                := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
-  developers              := List(
+  homepage                    := remoteUrl.map(u => url(s"https://${u.getHost}/${u.getPath.stripSuffix(".git")}")),
+  licenses                    := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
+  developers                  := List(
     Developer("nafg", "Naftoli Gugenheim", "98384+nafg@users.noreply.github.com", url("https://github.com/nafg"))
   ),
   dynverGitDescribeOutput ~= (_.map(o => o.copy(dirtySuffix = sbtdynver.GitDirtySuffix("")))),
-  dynverSonatypeSnapshots := true,
+  dynverSonatypeSnapshots     := true,
+  githubWorkflowScalaVersions := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
   githubWorkflowTargetTags ++= Seq("v*"),
   githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v"))),
   githubWorkflowPublish               := Seq(


### PR DESCRIPTION
This way, .mergify.yml won't need to be updated every time a new version is released.

This should also reduce merge conflicts.
